### PR TITLE
Add Bluetooth support for Android and iOS - with discovery, connectin management, and multiple printer operations things

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,22 @@
 This is a flutter plugin for the Link-OS Multiplatform SDK for [Zebra](https://www.zebra.com/ap/en/support-downloads/printer-software/link-os-multiplatform-sdk.html)
 
 ### Features
-| Feature                   | iOS                     | Android                 |
-|---------------------------|-------------------------|-------------------------|
-| Print ZPL from String     | :white_check_mark:      | :white_check_mark:      |
-| Print ZPL from file       | :white_check_mark:      | :white_check_mark:      |
-| Print PDF from byte array | :ballot_box_with_check: | :ballot_box_with_check: |
-| Print PDF from file       | :white_check_mark:      | :white_check_mark:      |
-| Get printer settings      | :white_check_mark:      | :white_check_mark:      |
-| Set printer settings      | :white_check_mark:      | :white_check_mark:      |
-| Check printer status      | :white_check_mark:      | :white_check_mark:      |
-| Print configuration label | :white_check_mark:      | :white_check_mark:      |
-| Run calibration           | :white_check_mark:      | :white_check_mark:      |
-| Reboot printer            | :white_check_mark:      | :white_check_mark:      |
+| Feature                   | iOS (TCP/IP)            | iOS (Bluetooth)         | Android (TCP/IP)        | Android (Bluetooth)     |
+|---------------------------|-------------------------|-------------------------|-------------------------|-------------------------|
+| Print ZPL from String     | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      |
+| Print ZPL from file       | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      |
+| Print PDF from byte array | :ballot_box_with_check: | :x:                     | :ballot_box_with_check: | :x:                     |
+| Print PDF from file       | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      |
+| Get printer settings      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      |
+| Set printer settings      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      |
+| Check printer status      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      |
+| Print configuration label | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      |
+| Run calibration           | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      |
+| Reboot printer            | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      | :white_check_mark:      |
 
-
-**Currently this plugin only supports TCP/IP connection to the Printer.** 
+### Connection Types
+- **TCP/IP**: Supported on both iOS and Android
+- **Bluetooth**: Supported on both iOS and Android (requires additional setup) 
 
 ### Note:
 Since v3.1.0+1 the plugin supports PDF direct printing on both iOS and Android, before this version, the PDF printing was only available on Android, and it was by using some kind of workaround converting the PDF to image and printing it as image, which was not reliable and caused some issues depending on the document dimensions, etc.
@@ -31,6 +32,8 @@ Steps:
 ------------------------
 
 ### iOS Setup
+
+#### Podfile
 ```yaml
 target 'Runner' do
   use_frameworks!
@@ -40,8 +43,48 @@ target 'Runner' do
 end
 ```
 
+#### Bluetooth Support (iOS)
+If you want to use Bluetooth connectivity on iOS, you need to configure your app for MFi (Made for iPhone) accessories:
+
+1. Add the following to your `Info.plist`:
+```xml
+<key>UISupportedExternalAccessoryProtocols</key>
+<array>
+    <string>com.zebra.rawport</string>
+</array>
+```
+
+2. Add the `ExternalAccessory` framework to your Xcode project.
+
+**Important:** On iOS, Bluetooth uses the printer's **serial number** instead of MAC address. Use `getBondedDevices()` to discover connected Zebra printers - the `address` field will contain the serial number to use with Bluetooth methods.
+
 ### Android Setup
-No setup required
+
+#### TCP/IP Only
+No setup required.
+
+#### Bluetooth Support
+If you want to use Bluetooth connectivity, you need to add the following permissions to your app's `AndroidManifest.xml`:
+
+```xml
+<!-- Bluetooth permissions for Android 11 and below -->
+<uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+
+<!-- Bluetooth permissions for Android 12+ -->
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+<!-- Optional: Only needed if you want to discover/scan for printers -->
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+```
+
+**Note:** You also need to request these permissions at runtime before using Bluetooth features. Consider using a package like `permission_handler` to handle runtime permission requests.
+
+### Bluetooth Device Identifier
+The Bluetooth methods use the `macAddress` parameter:
+- **Android**: Use the printer's MAC address (e.g., `"AC:3F:A4:12:34:56"`)
+- **iOS**: Use the printer's serial number (obtained from `getBondedDevices()`)
 
 ## How to use
 
@@ -220,8 +263,27 @@ zsdk.printPdfFileOverTCPIP(
  }
 ```
 
+## Bluetooth Examples (Android only)
 
-*Check the example code for more details*
+All Bluetooth methods mirror their TCP/IP counterparts, but use `macAddress` instead of `address` and `port`.
+
+### Example: Print ZPL over Bluetooth
+```dart
+zsdk.printZplDataOverBluetooth(
+  data: '^XA^FO17,16^GB379,371,8^FS^FT65,255^A0N,135,134^FDTEST^FS^XZ',
+  macAddress: 'AC:3F:A4:12:34:56',
+).then(value) {
+   final printerResponse = PrinterResponse.fromMap(value);
+   if(printerResponse.errorCode == ErrorCode.SUCCESS) {
+     //Do something
+   } else {
+     Cause cause = printerResponse.statusInfo.cause;
+     print(cause);
+   }
+ }
+```
+
+All Bluetooth methods mirror their TCP/IP counterparts (e.g., `printZplFileOverBluetooth`, `checkPrinterStatusOverBluetooth`, etc.).
 
 ### Tested Zebra Devices
 - Zebra ZT411 

--- a/android/src/main/java/com/plugin/flutter/zsdk/ZPrinter.java
+++ b/android/src/main/java/com/plugin/flutter/zsdk/ZPrinter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
 
+import com.zebra.sdk.comm.BluetoothConnection;
 import com.zebra.sdk.comm.Connection;
 import com.zebra.sdk.comm.ConnectionException;
 import com.zebra.sdk.comm.TcpConnection;
@@ -39,18 +40,33 @@ public class ZPrinter
     protected final Handler handler = new Handler();
     protected PrinterConf printerConf;
 
+    protected Connection activeBluetoothConnection;
+    protected boolean shouldManageConnection;
+
     public ZPrinter(Context context, MethodChannel channel, Result result, PrinterConf printerConf)
+    {
+        this(context, channel, result, printerConf, null, true);
+    }
+
+    public ZPrinter(Context context, MethodChannel channel, Result result, PrinterConf printerConf,
+                   Connection activeConnection, boolean shouldManageConnection)
     {
         this.context = context;
         this.channel = channel;
         this.result = result;
         this.printerConf = printerConf != null ? printerConf : new PrinterConf();
+        this.activeBluetoothConnection = activeConnection;
+        this.shouldManageConnection = shouldManageConnection;
     }
 
     private TcpConnection newConnection(String address, int tcpPort){
         int MAX_TIME_OUT_FOR_READ = 5000;
         int TIME_TO_WAIT_FOR_MORE_DATA = 0;
         return new TcpConnection(address, tcpPort, MAX_TIME_OUT_FOR_READ, TIME_TO_WAIT_FOR_MORE_DATA);
+    }
+
+    private BluetoothConnection newBluetoothConnection(String macAddress){
+        return new BluetoothConnection(macAddress);
     }
 
     protected void init(Connection connection){
@@ -527,5 +543,325 @@ public class ZPrinter
         }
 
         return scale;
+    }
+
+    public void doManualCalibrationOverBluetooth(final String macAddress) {
+        new Thread(() -> {
+            Connection connection;
+            ZebraPrinter printer = null;
+            try {
+                connection = newBluetoothConnection(macAddress);
+                connection.open();
+
+                try {
+                    printer = ZebraPrinterFactory.getInstance(connection);
+                    printer.calibrate();
+                    PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                            getStatusInfo(printer), "Printer status");
+                    handler.post(() -> result.success(response.toMap()));
+                } finally {
+                    connection.close();
+                }
+            } catch (ConnectionException e) {
+                onConnectionTimeOut(e);
+            } catch (Exception e) {
+                onException(e, printer);
+            }
+        }).start();
+    }
+
+    public void printConfigurationLabelOverBluetooth(final String macAddress) {
+        new Thread(() -> {
+            Connection connection;
+            ZebraPrinter printer = null;
+            try {
+                connection = newBluetoothConnection(macAddress);
+                connection.open();
+
+                try {
+                    printer = ZebraPrinterFactory.getInstance(connection);
+                    printer.printConfigurationLabel();
+                    PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                            getStatusInfo(printer), "Printer status");
+                    handler.post(() -> result.success(response.toMap()));
+                } finally {
+                    connection.close();
+                }
+            } catch (ConnectionException e) {
+                onConnectionTimeOut(e);
+            } catch (Exception e) {
+                onException(e, printer);
+            }
+        }).start();
+    }
+
+    public void checkPrinterStatusOverBluetooth(final String macAddress) {
+        new Thread(() -> {
+            Connection connection = null;
+            ZebraPrinter printer = null;
+            boolean shouldCloseConnection = shouldManageConnection;
+            try {
+                if (activeBluetoothConnection != null && !shouldManageConnection) {
+                    try {
+                        if (activeBluetoothConnection.isConnected()) {
+                            connection = activeBluetoothConnection;
+                            shouldCloseConnection = false;
+                        }
+                    } catch (Exception ignored) {
+                    }
+                }
+
+                if (connection == null) {
+                    connection = newBluetoothConnection(macAddress);
+                    connection.open();
+                    shouldCloseConnection = true;
+                }
+
+                try {
+                    printer = ZebraPrinterFactory.getInstance(connection);
+
+                    PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                            getStatusInfo(printer), "Printer status");
+                    handler.post(() -> result.success(response.toMap()));
+                } finally {
+                    if (shouldCloseConnection && connection != null) {
+                        connection.close();
+                    }
+                }
+            } catch (ConnectionException e) {
+                onConnectionTimeOut(e);
+            } catch (Exception e) {
+                onException(e, printer);
+            }
+        }).start();
+    }
+
+    public void getPrinterSettingsOverBluetooth(final String macAddress) {
+        new Thread(() -> {
+            Connection connection = null;
+            ZebraPrinter printer = null;
+            boolean shouldCloseConnection = shouldManageConnection;
+            try {
+                if (activeBluetoothConnection != null && !shouldManageConnection) {
+                    try {
+                        if (activeBluetoothConnection.isConnected()) {
+                            connection = activeBluetoothConnection;
+                            shouldCloseConnection = false;
+                        }
+                    } catch (Exception ignored) {
+                    }
+                }
+
+                if (connection == null) {
+                    connection = newBluetoothConnection(macAddress);
+                    connection.open();
+                    shouldCloseConnection = true;
+                }
+
+                try {
+                    printer = ZebraPrinterFactory.getInstance(connection);
+                    PrinterSettings settings = PrinterSettings.get(connection);
+                    PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                            getStatusInfo(printer), settings, "Printer status");
+                    handler.post(() -> result.success(response.toMap()));
+                } finally {
+                    if (shouldCloseConnection && connection != null) {
+                        connection.close();
+                    }
+                }
+            } catch (ConnectionException e) {
+                onConnectionTimeOut(e);
+            } catch (Exception e) {
+                onException(e, printer);
+            }
+        }).start();
+    }
+
+    public void setPrinterSettingsOverBluetooth(final String macAddress, final PrinterSettings settings) {
+        new Thread(() -> {
+            Connection connection;
+            ZebraPrinter printer = null;
+            try {
+                if (settings == null) throw new NullPointerException("Settings can't be null");
+
+                connection = newBluetoothConnection(macAddress);
+                connection.open();
+
+                try {
+                    printer = ZebraPrinterFactory.getInstance(connection);
+                    settings.apply(connection);
+                    if (!connection.isConnected()) {
+                        onPrinterRebooted("New settings required Printer to reboot");
+                        return;
+                    }
+                    PrinterSettings currentSettings = PrinterSettings.get(connection);
+                    PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                            getStatusInfo(printer), currentSettings, "Printer status");
+                    handler.post(() -> result.success(response.toMap()));
+                } finally {
+                    connection.close();
+                }
+            } catch (ConnectionException e) {
+                onConnectionTimeOut(e);
+            } catch (Exception e) {
+                onException(e, printer);
+            }
+        }).start();
+    }
+
+    /**
+     * @noinspection IOStreamConstructor
+     */
+    public void printPdfFileOverBluetooth(final String filePath, final String macAddress) {
+        new Thread(() -> {
+            try {
+                if (!new File(filePath).exists())
+                    throw new FileNotFoundException("The file: " + filePath + "doesn't exist");
+
+                doPrintDataStreamOverBluetooth(new FileInputStream(filePath), macAddress, false);
+            } catch (Exception e) {
+                onException(e, null);
+            }
+        }).start();
+    }
+
+    /** @noinspection IOStreamConstructor*/
+    public void printZplFileOverBluetooth(final String filePath, final String macAddress) {
+        new Thread(() -> {
+            try {
+                if (!new File(filePath).exists())
+                    throw new FileNotFoundException("The file: " + filePath + "doesn't exist");
+
+                doPrintDataStreamOverBluetooth(new FileInputStream(filePath), macAddress, true);
+            } catch (Exception e) {
+                onException(e, null);
+            }
+        }).start();
+    }
+
+    public void printZplDataOverBluetooth(final String data, final String macAddress) {
+        if (data == null || data.isEmpty()) throw new NullPointerException("ZPL data can not be empty");
+        new Thread(() -> doSimplePrintZplOverBluetooth(data, macAddress)).start();
+    }
+
+    private void doSimplePrintZplOverBluetooth(final String zplData, final String macAddress) {
+        Connection connection = null;
+        boolean shouldCloseConnection = shouldManageConnection;
+        try {
+            if (activeBluetoothConnection != null && !shouldManageConnection) {
+                try {
+                    if (activeBluetoothConnection.isConnected()) {
+                        connection = activeBluetoothConnection;
+                        shouldCloseConnection = false;
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+
+            if (connection == null) {
+                connection = newBluetoothConnection(macAddress);
+                connection.open();
+                shouldCloseConnection = true;
+            }
+
+            try {
+                connection.write(zplData.getBytes(Charset.forName("UTF-8")));
+
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+
+                PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                        new StatusInfo(Status.READY_TO_PRINT, Cause.UNKNOWN), "Successful print");
+                handler.post(() -> result.success(response.toMap()));
+
+            } finally {
+                if (shouldCloseConnection && connection != null) {
+                    connection.close();
+                }
+            }
+        } catch (ConnectionException e) {
+            onConnectionTimeOut(e);
+        } catch (Exception e) {
+            onException(e, null);
+        }
+    }
+
+    private void doPrintDataStreamOverBluetooth(final InputStream dataStream, final String macAddress, boolean isZPL) {
+        Connection connection = null;
+        ZebraPrinter printer = null;
+        boolean shouldCloseConnection = shouldManageConnection;
+        try {
+            if (dataStream == null) throw new NullPointerException("Data stream can not be empty");
+
+            if (activeBluetoothConnection != null && !shouldManageConnection) {
+                try {
+                    if (activeBluetoothConnection.isConnected()) {
+                        connection = activeBluetoothConnection;
+                        shouldCloseConnection = false;
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+
+            if (connection == null) {
+                connection = newBluetoothConnection(macAddress);
+                connection.open();
+                shouldCloseConnection = true;
+            }
+
+            try {
+                printer = ZebraPrinterFactory.getInstance(connection);
+                if (isReadyToPrint(printer)) {
+                    init(connection);
+                    if (isZPL) {
+                        changePrinterLanguage(connection, SGDParams.VALUE_ZPL_LANGUAGE);
+                    } else {
+                        if (enablePDFDirect(connection, true)) {
+                            onPrinterRebooted("Printer was rebooted to be able to use PDF Direct feature.");
+                            return;
+                        }
+                    }
+                    FileUtilities.sendFileContentsInChunks(connection, dataStream);
+                    PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                            getStatusInfo(printer), "Successful print");
+                    handler.post(() -> result.success(response.toMap()));
+                } else {
+                    PrinterResponse response = new PrinterResponse(ErrorCode.PRINTER_ERROR,
+                            getStatusInfo(printer), "Printer is not ready");
+                    handler.post(() -> result.error(ErrorCode.PRINTER_ERROR.name(),
+                            response.message, response.toMap()));
+                }
+
+            } finally {
+                if (shouldCloseConnection && connection != null) {
+                    connection.close();
+                }
+            }
+        } catch (ConnectionException e) {
+            onConnectionTimeOut(e);
+        } catch (Exception e) {
+            onException(e, printer);
+        }
+    }
+
+    public void rebootPrinterOverBluetooth(final String macAddress) {
+        new Thread(() -> {
+            try {
+                if (PrinterUtils.reboot(newBluetoothConnection(macAddress))) {
+                    onPrinterRebooted("Printer successfully rebooted");
+                } else {
+                    PrinterResponse response = new PrinterResponse(ErrorCode.EXCEPTION,
+                            new StatusInfo(Status.UNKNOWN, Cause.UNKNOWN), "Printer could not be rebooted.");
+                    handler.post(() -> result.error(response.errorCode.name(), response.message, response.toMap()));
+                }
+            } catch (ConnectionException e) {
+                onConnectionTimeOut(e);
+            } catch (Exception e) {
+                onException(e, null);
+            }
+        }).start();
     }
 }

--- a/android/src/main/java/com/plugin/flutter/zsdk/ZsdkPlugin.java
+++ b/android/src/main/java/com/plugin/flutter/zsdk/ZsdkPlugin.java
@@ -1,9 +1,29 @@
 package com.plugin.flutter.zsdk;
 
 import android.annotation.SuppressLint;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
 import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
 
 import androidx.annotation.NonNull;
+
+import com.zebra.sdk.comm.BluetoothConnection;
+import com.zebra.sdk.comm.Connection;
+import com.zebra.sdk.printer.PrinterLanguage;
+import com.zebra.sdk.printer.ZebraPrinter;
+import com.zebra.sdk.printer.ZebraPrinterFactory;
+import com.zebra.sdk.printer.discovery.BluetoothDiscoverer;
+import com.zebra.sdk.printer.discovery.DiscoveredPrinter;
+import com.zebra.sdk.printer.discovery.DiscoveryHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
@@ -15,6 +35,9 @@ import io.flutter.plugin.common.MethodChannel.Result;
 /** ZsdkPlugin */
 public class ZsdkPlugin implements FlutterPlugin, MethodCallHandler {
 
+  private Connection activeBluetoothConnection = null;
+  private String connectedBluetoothAddress = null;
+
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
     init(
@@ -25,6 +48,15 @@ public class ZsdkPlugin implements FlutterPlugin, MethodCallHandler {
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    if (activeBluetoothConnection != null) {
+      try {
+        activeBluetoothConnection.close();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      activeBluetoothConnection = null;
+      connectedBluetoothAddress = null;
+    }
     if(channel != null) channel.setMethodCallHandler(null);
   }
 
@@ -54,11 +86,30 @@ public class ZsdkPlugin implements FlutterPlugin, MethodCallHandler {
   static final String _PRINT_CONFIGURATION_LABEL_OVER_TCP_IP = "printConfigurationLabelOverTCPIP";
   static final String _REBOOT_PRINTER_OVER_TCP_IP = "rebootPrinterOverTCPIP";
 
+  /** Methods - Bluetooth */
+  static final String _PRINT_PDF_FILE_OVER_BLUETOOTH = "printPdfFileOverBluetooth";
+  static final String _PRINT_ZPL_FILE_OVER_BLUETOOTH = "printZplFileOverBluetooth";
+  static final String _PRINT_ZPL_DATA_OVER_BLUETOOTH = "printZplDataOverBluetooth";
+  static final String _CHECK_PRINTER_STATUS_OVER_BLUETOOTH = "checkPrinterStatusOverBluetooth";
+  static final String _GET_PRINTER_SETTINGS_OVER_BLUETOOTH = "getPrinterSettingsOverBluetooth";
+  static final String _SET_PRINTER_SETTINGS_OVER_BLUETOOTH = "setPrinterSettingsOverBluetooth";
+  static final String _DO_MANUAL_CALIBRATION_OVER_BLUETOOTH = "doManualCalibrationOverBluetooth";
+  static final String _PRINT_CONFIGURATION_LABEL_OVER_BLUETOOTH = "printConfigurationLabelOverBluetooth";
+  static final String _REBOOT_PRINTER_OVER_BLUETOOTH = "rebootPrinterOverBluetooth";
+
+  /** Methods - Bluetooth Connection Management */
+  static final String _CONNECT_BLUETOOTH = "connectBluetooth";
+  static final String _DISCONNECT_BLUETOOTH = "disconnectBluetooth";
+  static final String _IS_BLUETOOTH_CONNECTED = "isBluetoothConnected";
+  static final String _GET_BONDED_DEVICES = "getBondedDevices";
+  static final String _DISCOVER_BLUETOOTH_PRINTERS = "discoverBluetoothPrinters";
+
   /** Properties */
   static final String _filePath = "filePath";
   static final String _data = "data";
   static final String _address = "address";
   static final String _port = "port";
+  static final String _macAddress = "macAddress";
   static final String _cmWidth = "cmWidth";
   static final String _cmHeight = "cmHeight";
   static final String _orientation = "orientation";
@@ -82,6 +133,42 @@ public class ZsdkPlugin implements FlutterPlugin, MethodCallHandler {
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
     try
     {
+      switch (call.method) {
+        case _CONNECT_BLUETOOTH:
+          connectBluetooth(call.argument(_macAddress), result);
+          return;
+        case _DISCONNECT_BLUETOOTH:
+          disconnectBluetooth(result);
+          return;
+        case _IS_BLUETOOTH_CONNECTED:
+          String checkAddress = call.argument(_macAddress);
+          result.success(isBluetoothConnected(checkAddress));
+          return;
+        case _GET_BONDED_DEVICES:
+          getBondedDevices(result);
+          return;
+        case _DISCOVER_BLUETOOTH_PRINTERS:
+          discoverBluetoothPrinters(result);
+          return;
+      }
+
+      String requestedMac = call.argument(_macAddress);
+      Connection connectionToUse = null;
+      boolean shouldManageConnection = true;
+
+      if (requestedMac != null && activeBluetoothConnection != null &&
+              requestedMac.equalsIgnoreCase(connectedBluetoothAddress)) {
+        try {
+          if (activeBluetoothConnection.isConnected()) {
+            connectionToUse = activeBluetoothConnection;
+            shouldManageConnection = false;
+          }
+        } catch (Exception ignored) {
+          activeBluetoothConnection = null;
+          connectedBluetoothAddress = null;
+        }
+      }
+
       ZPrinter printer = new ZPrinter(
           context,
           channel,
@@ -91,7 +178,9 @@ public class ZsdkPlugin implements FlutterPlugin, MethodCallHandler {
               call.argument(_cmHeight),
               call.argument(_dpi),
               Orientation.getValueOfName(call.argument(_orientation))
-          )
+          ),
+          connectionToUse,
+          shouldManageConnection
       );
       switch(call.method){
         case _DO_MANUAL_CALIBRATION_OVER_TCP_IP:
@@ -152,6 +241,55 @@ public class ZsdkPlugin implements FlutterPlugin, MethodCallHandler {
               call.argument(_port)
           );
           break;
+        case _DO_MANUAL_CALIBRATION_OVER_BLUETOOTH:
+          printer.doManualCalibrationOverBluetooth(
+              call.argument(_macAddress)
+          );
+          break;
+        case _PRINT_CONFIGURATION_LABEL_OVER_BLUETOOTH:
+          printer.printConfigurationLabelOverBluetooth(
+              call.argument(_macAddress)
+          );
+          break;
+        case _CHECK_PRINTER_STATUS_OVER_BLUETOOTH:
+          printer.checkPrinterStatusOverBluetooth(
+              call.argument(_macAddress)
+          );
+          break;
+        case _GET_PRINTER_SETTINGS_OVER_BLUETOOTH:
+          printer.getPrinterSettingsOverBluetooth(
+              call.argument(_macAddress)
+          );
+          break;
+        case _SET_PRINTER_SETTINGS_OVER_BLUETOOTH:
+          printer.setPrinterSettingsOverBluetooth(
+              call.argument(_macAddress),
+              new PrinterSettings(call.arguments())
+          );
+          break;
+        case _PRINT_PDF_FILE_OVER_BLUETOOTH:
+          printer.printPdfFileOverBluetooth(
+              call.argument(_filePath),
+              call.argument(_macAddress)
+          );
+          break;
+        case _PRINT_ZPL_FILE_OVER_BLUETOOTH:
+          printer.printZplFileOverBluetooth(
+              call.argument(_filePath),
+              call.argument(_macAddress)
+          );
+          break;
+        case _PRINT_ZPL_DATA_OVER_BLUETOOTH:
+          printer.printZplDataOverBluetooth(
+              call.argument(_data),
+              call.argument(_macAddress)
+          );
+          break;
+        case _REBOOT_PRINTER_OVER_BLUETOOTH:
+          printer.rebootPrinterOverBluetooth(
+              call.argument(_macAddress)
+          );
+          break;
         case _PRINT_PDF_DATA_OVER_TCP_IP:
         default:
           result.notImplemented();
@@ -162,5 +300,152 @@ public class ZsdkPlugin implements FlutterPlugin, MethodCallHandler {
       e.printStackTrace();
       result.error(ErrorCode.EXCEPTION.name(), e.getMessage(), null);
     }
+  }
+
+  private void connectBluetooth(String macAddress, Result result) {
+    if (macAddress == null || macAddress.isEmpty()) {
+      result.error("INVALID_ADDRESS", "MAC address is required", null);
+      return;
+    }
+
+    if (activeBluetoothConnection != null) {
+      try {
+        activeBluetoothConnection.close();
+      } catch (Exception e) {
+        // Ignored
+      }
+      activeBluetoothConnection = null;
+      connectedBluetoothAddress = null;
+    }
+
+    new Thread(() -> {
+      try {
+        BluetoothConnection connection = new BluetoothConnection(macAddress);
+        connection.open();
+
+        ZebraPrinter printer = ZebraPrinterFactory.getInstance(connection);
+        PrinterLanguage language = printer.getPrinterControlLanguage();
+
+        activeBluetoothConnection = connection;
+        connectedBluetoothAddress = macAddress;
+
+        new Handler(Looper.getMainLooper()).post(() -> {
+          Map<String, Object> response = new HashMap<>();
+          response.put("connected", true);
+          response.put("address", macAddress);
+          response.put("language", language.toString());
+          result.success(response);
+        });
+
+      } catch (Exception e) {
+        e.printStackTrace();
+        activeBluetoothConnection = null;
+        connectedBluetoothAddress = null;
+        new Handler(Looper.getMainLooper()).post(() -> {
+          result.error("CONNECTION_FAILED", "Failed to connect: " + e.getMessage(), null);
+        });
+      }
+    }).start();
+  }
+
+  private void disconnectBluetooth(Result result) {
+    if (activeBluetoothConnection == null) {
+      result.success(true);
+      return;
+    }
+
+    new Thread(() -> {
+      try {
+        activeBluetoothConnection.close();
+      } catch (Exception e) {
+        // Ignored
+      }
+      activeBluetoothConnection = null;
+      connectedBluetoothAddress = null;
+
+      new Handler(Looper.getMainLooper()).post(() -> {
+        result.success(true);
+      });
+    }).start();
+  }
+
+  private boolean isBluetoothConnected(String macAddress) {
+    if (activeBluetoothConnection == null || connectedBluetoothAddress == null) {
+      return false;
+    }
+    if (macAddress != null && !macAddress.isEmpty()) {
+      return macAddress.equalsIgnoreCase(connectedBluetoothAddress);
+    }
+    try {
+      return activeBluetoothConnection.isConnected();
+    } catch (Exception ignored) {
+      return false;
+    }
+  }
+
+  @SuppressWarnings("MissingPermission")
+  private void getBondedDevices(Result result) {
+    try {
+      BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+
+      if (bluetoothAdapter == null) {
+        result.error("BLUETOOTH_NOT_AVAILABLE", "Bluetooth is not available on this device", null);
+        return;
+      }
+
+      Set<BluetoothDevice> bondedDevices = bluetoothAdapter.getBondedDevices();
+      List<Map<String, String>> deviceList = new ArrayList<>();
+
+      for (BluetoothDevice device : bondedDevices) {
+        Map<String, String> deviceMap = new HashMap<>();
+        deviceMap.put("name", device.getName() != null ? device.getName() : "Unknown");
+        deviceMap.put("address", device.getAddress());
+        deviceList.add(deviceMap);
+      }
+
+      result.success(deviceList);
+    } catch (Exception e) {
+      e.printStackTrace();
+      result.error("BLUETOOTH_ERROR", "Failed to get bonded devices: " + e.getMessage(), null);
+    }
+  }
+
+  private void discoverBluetoothPrinters(Result result) {
+    new Thread(() -> {
+      try {
+        List<Map<String, String>> printerList = new ArrayList<>();
+
+        BluetoothDiscoverer.findPrinters(context, new DiscoveryHandler() {
+          @Override
+          public void foundPrinter(DiscoveredPrinter printer) {
+            Map<String, String> printerMap = new HashMap<>();
+            printerMap.put("address", printer.address);
+            String name = printer.getDiscoveryDataMap().get("FRIENDLY_NAME");
+            printerMap.put("name", name != null ? name : "Zebra Printer");
+            printerList.add(printerMap);
+          }
+
+          @Override
+          public void discoveryFinished() {
+            new Handler(Looper.getMainLooper()).post(() -> {
+              result.success(printerList);
+            });
+          }
+
+          @Override
+          public void discoveryError(String message) {
+            new Handler(Looper.getMainLooper()).post(() -> {
+              result.error("DISCOVERY_ERROR", message, null);
+            });
+          }
+        });
+
+      } catch (Exception e) {
+        e.printStackTrace();
+        new Handler(Looper.getMainLooper()).post(() -> {
+          result.error("DISCOVERY_ERROR", "Failed to discover printers: " + e.getMessage(), null);
+        });
+      }
+    }).start();
   }
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,14 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- Bluetooth permissions for Android 11 and below -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+
+    <!-- Bluetooth permissions for Android 12+ -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
     <!--
      io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate printMethod.

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -34,6 +34,8 @@
 	<array>
 		<string>com.zebra.rawport</string>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>This app uses Bluetooth to connect to Zebra printers</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:zsdk/zsdk.dart' as Printer;
 import 'dart:io';
 
@@ -22,6 +23,10 @@ const String btnDoManualCalibration = 'btnDoManualCalibration';
 const String btnPrintConfigurationLabel = 'btnPrintConfigurationLabel';
 const String btnRebootPrinter = 'btnRebootPrinter';
 
+const String btnGetBondedDevices = 'btnGetBondedDevices';
+const String btnDiscoverPrinters = 'btnDiscoverPrinters';
+const String btnPrintZplDataOverBluetooth = 'btnPrintZplDataOverBluetooth';
+
 class MyApp extends StatefulWidget {
   final Printer.ZSDK zsdk = Printer.ZSDK();
 
@@ -42,6 +47,8 @@ enum OperationStatus {
 class _MyAppState extends State<MyApp> {
   final addressIpController = TextEditingController(text: "10.0.0.11");
   final addressPortController = TextEditingController();
+  final btMacAddressController = TextEditingController();
+  List<Map<String, String>> bondedDevices = [];
   final pathController = TextEditingController();
   final zplDataController = TextEditingController(
       text: '^XA^FO17,16^GB379,371,8^FS^FT65,255^A0N,135,134^FDTEST^FS^XZ');
@@ -78,8 +85,16 @@ class _MyAppState extends State<MyApp> {
   OperationStatus settingsStatus = OperationStatus.NONE;
   OperationStatus calibrationStatus = OperationStatus.NONE;
   OperationStatus rebootingStatus = OperationStatus.NONE;
+  OperationStatus btStatus = OperationStatus.NONE;
+  String? btMessage;
   String? filePath;
   String? zplData;
+
+  Future<bool> _requestBluetoothPermissions() async {
+    var btConnect = await Permission.bluetoothConnect.request();
+    var btScan = await Permission.bluetoothScan.request();
+    return btConnect.isGranted && btScan.isGranted;
+  }
 
   @override
   void initState() {
@@ -886,6 +901,118 @@ class _MyAppState extends State<MyApp> {
                   textAlign: TextAlign.center,
                 ),
               ),
+              const SizedBox(height: 32),
+              const Text(
+                'Bluetooth',
+                style: TextStyle(fontSize: 18),
+              ),
+              const Divider(color: Colors.transparent),
+              Card(
+                elevation: 4,
+                margin: const EdgeInsets.all(8),
+                child: Container(
+                  padding: const EdgeInsets.all(8),
+                  child: Column(
+                    children: <Widget>[
+                      TextField(
+                        controller: btMacAddressController,
+                        decoration: const InputDecoration(
+                            labelText: "Printer MAC address"),
+                      ),
+                      const SizedBox(height: 8),
+                      if (bondedDevices.isNotEmpty)
+                        DropdownButtonFormField<String>(
+                          decoration: const InputDecoration(
+                              labelText: "Select bonded device"),
+                          items: bondedDevices
+                              .map((d) => DropdownMenuItem(
+                                    value: d['address'],
+                                    child: Text(
+                                        "${d['name']} (${d['address']})"),
+                                  ))
+                              .toList(),
+                          onChanged: (value) {
+                            if (value != null) {
+                              setState(() {
+                                btMacAddressController.text = value;
+                              });
+                            }
+                          },
+                        ),
+                      const SizedBox(height: 16),
+                      Visibility(
+                        visible: btStatus != OperationStatus.NONE,
+                        child: Column(
+                          children: <Widget>[
+                            Text(
+                              "$btMessage",
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.bold,
+                                  color: getOperationStatusColor(btStatus)),
+                            ),
+                            const SizedBox(height: 16),
+                          ],
+                        ),
+                      ),
+                      Row(
+                        children: <Widget>[
+                          Expanded(
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.indigo,
+                                foregroundColor: Colors.white,
+                              ),
+                              onPressed: () => onClick(btnGetBondedDevices),
+                              child: Text(
+                                "Bonded".toUpperCase(),
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.deepOrange,
+                                foregroundColor: Colors.white,
+                              ),
+                              onPressed: btStatus == OperationStatus.RECEIVING
+                                  ? null
+                                  : () => onClick(btnDiscoverPrinters),
+                              child: Text(
+                                "Scan".toUpperCase(),
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: <Widget>[
+                          Expanded(
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.teal,
+                                foregroundColor: Colors.white,
+                              ),
+                              onPressed: btStatus == OperationStatus.SENDING
+                                  ? null
+                                  : () => onClick(btnPrintZplDataOverBluetooth),
+                              child: Text(
+                                "Print ZPL over Bluetooth".toUpperCase(),
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
               const SizedBox(
                 height: 100,
               ),
@@ -1421,6 +1548,106 @@ class _MyAppState extends State<MyApp> {
             }
             setState(() {
               printStatus = OperationStatus.ERROR;
+            });
+          });
+          break;
+        case btnGetBondedDevices:
+          setState(() {
+            btMessage = "Requesting permissions...";
+            btStatus = OperationStatus.RECEIVING;
+          });
+          if (!await _requestBluetoothPermissions()) {
+            setState(() {
+              btStatus = OperationStatus.ERROR;
+              btMessage = "Bluetooth permissions denied";
+            });
+            break;
+          }
+          setState(() {
+            btMessage = "Getting bonded devices...";
+          });
+          widget.zsdk.getBondedDevices().then((devices) {
+            setState(() {
+              bondedDevices = devices;
+              btStatus = OperationStatus.SUCCESS;
+              btMessage = "Found ${devices.length} bonded device(s)";
+            });
+          }, onError: (error, stacktrace) {
+            setState(() {
+              btStatus = OperationStatus.ERROR;
+              btMessage = error.toString();
+            });
+          });
+          break;
+        case btnDiscoverPrinters:
+          setState(() {
+            btMessage = "Requesting permissions...";
+            btStatus = OperationStatus.RECEIVING;
+          });
+          if (!await _requestBluetoothPermissions()) {
+            setState(() {
+              btStatus = OperationStatus.ERROR;
+              btMessage = "Bluetooth permissions denied";
+            });
+            break;
+          }
+          setState(() {
+            btMessage = "Scanning for Zebra printers...";
+          });
+          widget.zsdk.discoverBluetoothPrinters().then((devices) {
+            setState(() {
+              bondedDevices = devices;
+              btStatus = OperationStatus.SUCCESS;
+              btMessage = "Found ${devices.length} printer(s)";
+            });
+          }, onError: (error, stacktrace) {
+            setState(() {
+              btStatus = OperationStatus.ERROR;
+              btMessage = error.toString();
+            });
+          });
+          break;
+        case btnPrintZplDataOverBluetooth:
+          zplData = zplDataController.text;
+          if (zplData == null || zplData!.isEmpty) {
+            throw Exception("ZPL data can't be empty");
+          }
+          if (btMacAddressController.text.isEmpty) {
+            throw Exception("MAC address can't be empty");
+          }
+          setState(() {
+            btMessage = "Print job started...";
+            btStatus = OperationStatus.SENDING;
+          });
+          widget.zsdk
+              .printZplDataOverBluetooth(
+                  data: zplData!,
+                  macAddress: btMacAddressController.text)
+              .then((value) {
+            setState(() {
+              btStatus = OperationStatus.SUCCESS;
+              btMessage = "$value";
+            });
+          }, onError: (error, stacktrace) {
+            try {
+              throw error;
+            } on PlatformException catch (e) {
+              Printer.PrinterResponse printerResponse;
+              try {
+                printerResponse = Printer.PrinterResponse.fromMap(e.details);
+                btMessage =
+                    "${printerResponse.message} ${printerResponse.errorCode} ${printerResponse.statusInfo.status} ${printerResponse.statusInfo.cause}";
+              } catch (e) {
+                print(e);
+                btMessage = e.toString();
+              }
+            } on MissingPluginException catch (e) {
+              btMessage = "${e.message}";
+            } catch (e) {
+              btMessage = e.toString();
+            }
+            setState(() {
+              btStatus = OperationStatus.ERROR;
             });
           });
           break;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^8.3.5
+  permission_handler: ^11.3.1
   zsdk:
     path: ../
 

--- a/ios/Classes/ZPrinter.h
+++ b/ios/Classes/ZPrinter.h
@@ -38,6 +38,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (StatusInfo *) getStatusInfo:(nullable id<ZebraPrinter, NSObject>)printer;
 - (void) changePrinterLanguage:(id<ZebraPrinterConnection, NSObject>)connection language:(NSString *)language;
 - (void) rebootPrinter:(NSString *)address port:(NSNumber *)port;
+- (void) doManualCalibrationOverBluetooth:(NSString *)macAddress;
+- (void) printConfigurationLabelOverBluetooth:(NSString *)macAddress;
+- (void) checkPrinterStatusOverBluetooth:(NSString *)macAddress;
+- (void) getPrinterSettingsOverBluetooth:(NSString *)macAddress;
+- (void) setPrinterSettingsOverBluetooth:(NSString *)macAddress settings:(PrinterSettings *)settings;
+- (void) printPdfFileOverBluetooth:(NSString *)filePath macAddress:(NSString *)macAddress;
+- (void) printZplFileOverBluetooth:(NSString *)filePath macAddress:(NSString *)macAddress;
+- (void) printZplDataOverBluetooth:(NSString *)data macAddress:(NSString *)macAddress;
+- (void) doPrintOverBluetooth:(nullable NSString *)data filePath:(nullable NSString *)filePath macAddress:(NSString *)macAddress isZPL:(Boolean)isZPL;
+- (void) rebootPrinterOverBluetooth:(NSString *)macAddress;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Classes/ZPrinter.m
+++ b/ios/Classes/ZPrinter.m
@@ -8,6 +8,7 @@
 #import "ZPrinter.h"
 #import "ZebraPrinterFactory.h"
 #import "TcpPrinterConnection.h"
+#import "MfiBtPrinterConnection.h"
 #import "ErrorCodeUtils.h"
 #import "PrinterResponse.h"
 #import "SGDParams.h"
@@ -368,10 +369,258 @@ const int TIME_TO_WAIT_FOR_MORE_DATA = 0;
         id<ZebraPrinterConnection,NSObject> connection;
         @try {
             int tcpPort = ![ObjectUtils isNull:port] ? [port intValue] : DEFAULT_ZPL_TCP_PORT;
-            
+
             connection = [ZPrinter initWithAddress:address andWithPort:tcpPort];
             if(![connection open]) return [self onConnectionTimeOut];
-            
+
+            if([PrinterUtils reboot:connection]) {
+                [self onPrinterRebooted:@"Printer successfully rebooted"];
+            } else {
+                StatusInfo *statusInfo = [[StatusInfo alloc] init:UNKNOWN_STATUS cause:UNKNOWN_CAUSE];
+                PrinterResponse *response = [[PrinterResponse alloc] init:EXCEPTION statusInfo:statusInfo message:@"Printer could not be rebooted."];
+                self.result([FlutterError errorWithCode:[response getErrorCode] message: response.message details:[response toMap]]);
+            }
+        } @catch (NSException *e) {
+            [self onException:nil exception:e];
+        } @finally {
+            if(connection != nil) [connection close];
+        }
+    });
+}
+
+- (void)doManualCalibrationOverBluetooth:(NSString *)macAddress {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        id<ZebraPrinter,NSObject> printer;
+        id<ZebraPrinterConnection,NSObject> connection;
+        @try {
+            connection = [[MfiBtPrinterConnection alloc] initWithSerialNumber:macAddress];
+            if(![connection open]) return [self onConnectionTimeOut];
+            NSError *error = nil;
+            @try {
+                printer = [ZebraPrinterFactory getInstance:connection error:&error];
+                [SGD DO:SGDParams.KEY_MANUAL_CALIBRATION withValue:nil andWithPrinterConnection:connection error:&error];
+
+                if (![ObjectUtils isNull:error])
+                    @throw [NSException exceptionWithName:@"Printer error" reason:[error description] userInfo:nil];
+                else {
+                    StatusInfo *statusInfo = [self getStatusInfo:printer];
+                    PrinterResponse *response = [[PrinterResponse alloc] init:SUCCESS statusInfo:statusInfo message:@"Printer status"];
+                    self.result([response toMap]);
+                }
+            }
+            @catch (NSException *e) {
+                @throw e;
+            } @finally {
+                [connection close];
+            }
+        }
+        @catch (NSException *e) {
+            [self onException:printer exception:e];
+        }
+    });
+}
+
+- (void)printConfigurationLabelOverBluetooth:(NSString *)macAddress {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        id<ZebraPrinter,NSObject> printer;
+        id<ZebraPrinterConnection,NSObject> connection;
+        @try {
+            connection = [[MfiBtPrinterConnection alloc] initWithSerialNumber:macAddress];
+            if(![connection open]) return [self onConnectionTimeOut];
+            NSError *error = nil;
+            @try {
+                printer = [ZebraPrinterFactory getInstance:connection error:&error];
+                id<ToolsUtil,NSObject> toolsUtils = [printer getToolsUtil];
+                [toolsUtils printConfigurationLabel:&error];
+
+                if (![ObjectUtils isNull:error])
+                    @throw [NSException exceptionWithName:@"Printer error" reason:[error description] userInfo:nil];
+                else {
+                    StatusInfo *statusInfo = [self getStatusInfo:printer];
+                    PrinterResponse *response = [[PrinterResponse alloc] init:SUCCESS statusInfo:statusInfo message:@"Printer status"];
+                    self.result([response toMap]);
+                }
+            }
+            @catch (NSException *e) {
+                @throw e;
+            } @finally {
+                [connection close];
+            }
+        }
+        @catch (NSException *e) {
+            [self onException:printer exception:e];
+        }
+    });
+}
+
+- (void)checkPrinterStatusOverBluetooth:(NSString *)macAddress {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        id<ZebraPrinter,NSObject> printer;
+        id<ZebraPrinterConnection,NSObject> connection;
+        @try {
+            connection = [[MfiBtPrinterConnection alloc] initWithSerialNumber:macAddress];
+            if(![connection open]) return [self onConnectionTimeOut];
+            NSError *error = nil;
+            @try {
+                printer = [ZebraPrinterFactory getInstance:connection error:&error];
+                StatusInfo *statusInfo = [self getStatusInfo:printer];
+                PrinterResponse *response = [[PrinterResponse alloc] init:SUCCESS statusInfo:statusInfo message:@"Printer status"];
+                self.result([response toMap]);
+            }
+            @catch (NSException *e) {
+                @throw e;
+            } @finally {
+                [connection close];
+            }
+        }
+        @catch (NSException *e) {
+            [self onException:printer exception:e];
+        }
+    });
+}
+
+- (void)getPrinterSettingsOverBluetooth:(NSString *)macAddress {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        id<ZebraPrinter,NSObject> printer;
+        id<ZebraPrinterConnection,NSObject> connection;
+        @try {
+            connection = [[MfiBtPrinterConnection alloc] initWithSerialNumber:macAddress];
+            if(![connection open]) return [self onConnectionTimeOut];
+            NSError *error = nil;
+            @try {
+                printer = [ZebraPrinterFactory getInstance:connection error:&error];
+                PrinterSettings *settings = [PrinterSettings get:connection];
+                StatusInfo *statusInfo = [self getStatusInfo:printer];
+                PrinterResponse *response = [[PrinterResponse alloc] initWithSettings:SUCCESS statusInfo:statusInfo settings:settings message:@"Printer status"];
+                self.result([response toMap]);
+            }
+            @catch (NSException *e) {
+                @throw e;
+            } @finally {
+                [connection close];
+            }
+        }
+        @catch (NSException *e) {
+            [self onException:printer exception:e];
+        }
+    });
+}
+
+- (void)setPrinterSettingsOverBluetooth:(NSString *)macAddress settings:(PrinterSettings *)settings {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        id<ZebraPrinter,NSObject> printer;
+        id<ZebraPrinterConnection,NSObject> connection;
+        @try {
+            if([ObjectUtils isNull:settings])
+                @throw [NSException exceptionWithName:@"Printer Error" reason:@"Settings can't be null" userInfo:nil];
+
+            connection = [[MfiBtPrinterConnection alloc] initWithSerialNumber:macAddress];
+            if(![connection open]) return [self onConnectionTimeOut];
+            NSError *error = nil;
+            @try {
+                printer = [ZebraPrinterFactory getInstance:connection error:&error];
+                [settings apply:connection];
+                if(![connection isConnected]) {
+                    [self onPrinterRebooted:@"New settings required Printer to reboot"];
+                    return;
+                }
+                PrinterSettings *currentSettings = [PrinterSettings get:connection];
+                StatusInfo *statusInfo = [self getStatusInfo:printer];
+                PrinterResponse *response = [[PrinterResponse alloc] initWithSettings:SUCCESS statusInfo:statusInfo settings:currentSettings message:@"Printer status"];
+                self.result([response toMap]);
+            }
+            @catch (NSException *e) {
+                @throw e;
+            } @finally {
+                [connection close];
+            }
+        }
+        @catch (NSException *e) {
+            [self onException:printer exception:e];
+        }
+    });
+}
+
+- (void)printPdfFileOverBluetooth:(NSString *)filePath macAddress:(NSString *)macAddress {
+    [self doPrintOverBluetooth:nil filePath:filePath macAddress:macAddress isZPL:false];
+}
+
+- (void)printZplFileOverBluetooth:(NSString *)filePath macAddress:(NSString *)macAddress {
+    [self doPrintOverBluetooth:nil filePath:filePath macAddress:macAddress isZPL:true];
+}
+
+- (void)printZplDataOverBluetooth:(NSString *)data macAddress:(NSString *)macAddress {
+    [self doPrintOverBluetooth:data filePath:nil macAddress:macAddress isZPL:true];
+}
+
+- (void)doPrintOverBluetooth:(nullable NSString *)data filePath:(nullable NSString *)filePath macAddress:(NSString *)macAddress isZPL:(Boolean)isZPL {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        id<ZebraPrinterConnection,NSObject> connection;
+        @try {
+            connection = [[MfiBtPrinterConnection alloc] initWithSerialNumber:macAddress];
+            if(![connection open]) return [self onConnectionTimeOut];
+            NSError *error = nil;
+            @try {
+                if (![ObjectUtils isNull:data]) {
+                    [connection write:[data dataUsingEncoding:NSUTF8StringEncoding] error:&error];
+
+                    if (![ObjectUtils isNull:error])
+                        @throw [NSException exceptionWithName:@"Printer error" reason:[error description] userInfo:nil];
+                    else {
+                        StatusInfo *statusInfo = [[StatusInfo alloc] init:READY_TO_PRINT cause:UNKNOWN_CAUSE];
+                        PrinterResponse *response = [[PrinterResponse alloc] init:SUCCESS statusInfo:statusInfo message:@"Successful print"];
+                        self.result([response toMap]);
+                    }
+                } else if (![ObjectUtils isNull:filePath]) {
+                    id<ZebraPrinter,NSObject> printer = [ZebraPrinterFactory getInstance:connection error:&error];
+                    if ([self isReadyToPrint:printer]) {
+                        [self initValues:connection];
+
+                        if(isZPL) {
+                            [self changePrinterLanguage:connection language:SGDParams.VALUE_ZPL_LANGUAGE];
+                        } else {
+                            if ([self enablePDFDirect:connection enabled:true]) {
+                                [self onPrinterRebooted:@"Printer was rebooted to be able to use PDF Direct feature."];
+                                return;
+                            }
+                        }
+
+                        id<FileUtil,NSObject> fileUtil = [printer getFileUtil];
+                        [fileUtil sendFileContents:filePath error:&error];
+
+                        if (![ObjectUtils isNull:error])
+                            @throw [NSException exceptionWithName:@"Printer error" reason:[error description] userInfo:nil];
+                        else {
+                            StatusInfo *statusInfo = [self getStatusInfo:printer];
+                            PrinterResponse *response = [[PrinterResponse alloc] init:SUCCESS statusInfo:statusInfo message:@"Successful print"];
+                            self.result([response toMap]);
+                        }
+                    } else {
+                        StatusInfo *statusInfo = [self getStatusInfo:printer];
+                        PrinterResponse *response = [[PrinterResponse alloc] init:PRINTER_ERROR statusInfo:statusInfo message:@"Printer is not ready"];
+                        self.result([FlutterError errorWithCode:[response getErrorCode] message: response.message details:[response toMap]]);
+                    }
+                }
+            }
+            @catch (NSException *e) {
+                @throw e;
+            } @finally {
+                [connection close];
+            }
+        }
+        @catch (NSException *e) {
+            [self onException:nil exception:e];
+        }
+    });
+}
+
+- (void)rebootPrinterOverBluetooth:(NSString *)macAddress {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        id<ZebraPrinterConnection,NSObject> connection;
+        @try {
+            connection = [[MfiBtPrinterConnection alloc] initWithSerialNumber:macAddress];
+            if(![connection open]) return [self onConnectionTimeOut];
+
             if([PrinterUtils reboot:connection]) {
                 [self onPrinterRebooted:@"Printer successfully rebooted"];
             } else {

--- a/ios/Classes/ZsdkPlugin.h
+++ b/ios/Classes/ZsdkPlugin.h
@@ -1,9 +1,7 @@
 #import <Flutter/Flutter.h>
+#import "ZebraPrinterConnection.h"
 
 @interface ZsdkPlugin : NSObject<FlutterPlugin>
 @property FlutterMethodChannel* channel;
 - (id) init:(id<FlutterPluginRegistrar, NSObject>) registrar;
-- (void)discoverBluetoothDevices:(FlutterResult)result;
-- (void)getDeviceProperties:(NSString*) serial result:(FlutterResult)result;
-- (void)sendZplOverBluetooth:(NSString *)serial data:(NSString*)data result:(FlutterResult)result;
 @end

--- a/ios/Classes/ZsdkPlugin.m
+++ b/ios/Classes/ZsdkPlugin.m
@@ -37,11 +37,26 @@ NSString* _DO_MANUAL_CALIBRATION_OVER_TCP_IP = @"doManualCalibrationOverTCPIP";
 NSString* _PRINT_CONFIGURATION_LABEL_OVER_TCP_IP = @"printConfigurationLabelOverTCPIP";
 NSString* _REBOOT_PRINTER_OVER_TCP_IP = @"rebootPrinterOverTCPIP";
 
+/* Methods - Bluetooth */
+NSString* _PRINT_PDF_FILE_OVER_BLUETOOTH = @"printPdfFileOverBluetooth";
+NSString* _PRINT_ZPL_FILE_OVER_BLUETOOTH = @"printZplFileOverBluetooth";
+NSString* _PRINT_ZPL_DATA_OVER_BLUETOOTH = @"printZplDataOverBluetooth";
+NSString* _CHECK_PRINTER_STATUS_OVER_BLUETOOTH = @"checkPrinterStatusOverBluetooth";
+NSString* _GET_PRINTER_SETTINGS_OVER_BLUETOOTH = @"getPrinterSettingsOverBluetooth";
+NSString* _SET_PRINTER_SETTINGS_OVER_BLUETOOTH = @"setPrinterSettingsOverBluetooth";
+NSString* _DO_MANUAL_CALIBRATION_OVER_BLUETOOTH = @"doManualCalibrationOverBluetooth";
+NSString* _PRINT_CONFIGURATION_LABEL_OVER_BLUETOOTH = @"printConfigurationLabelOverBluetooth";
+NSString* _REBOOT_PRINTER_OVER_BLUETOOTH = @"rebootPrinterOverBluetooth";
+
+/* Methods - Bluetooth Device Discovery */
+NSString* _GET_BONDED_DEVICES = @"getBondedDevices";
+
 /* Properties */
 NSString* _filePath = @"filePath";
 NSString* _data = @"data";
 NSString* _address = @"address";
 NSString* _port = @"port";
+NSString* _macAddress = @"macAddress";
 NSString* _cmWidth = @"cmWidth";
 NSString* _cmHeight = @"cmHeight";
 NSString* _orientation = @"orientation";
@@ -57,36 +72,6 @@ NSString* _dpi = @"dpi";
     return self;
 }
 
-- (void)discoverBluetoothDevices:(FlutterResult)result {
-    @try {
-        NSString *serialNumber = @"";
-        NSString *name = @"";
-        
-        NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
-        
-        EAAccessoryManager *sam = [EAAccessoryManager sharedAccessoryManager];
-        NSArray * connectedAccessories = [sam connectedAccessories];
-        for (EAAccessory *accessory in connectedAccessories) {
-            if([accessory.protocolStrings indexOfObject:@"com.zebra.rawport"] != NSNotFound){
-                serialNumber = accessory.serialNumber;
-                name = accessory.name;
-                
-                [dict setObject:name forKey:serialNumber];
-            }
-        }
-        result(dict);
-    }
-    @catch (NSException *exception) {
-        result([FlutterError errorWithCode:@"Error"
-                                       message: exception.reason
-                                       details:nil]);
-    }
-}
-- (void)getDeviceProperties:(NSString*) serial result:(FlutterResult)result {
-     NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
-     [dict setObject:@"Not Implemented" forKey:@"error"];
-     result(dict);
-}
 - (void)getBatteryLevel:(NSString*) serial result:(FlutterResult)result {
    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
         @try {
@@ -207,6 +192,26 @@ NSString* _dpi = @"dpi";
             [printer printZplDataOverTCPIP:arguments[_data] address:arguments[_address] port:arguments[_port]];
         else if ([_REBOOT_PRINTER_OVER_TCP_IP isEqualToString:call.method])
             [printer rebootPrinter:arguments[_address] port:arguments[_port]];
+        else if ([_GET_BONDED_DEVICES isEqualToString:call.method])
+            [self getBondedDevicesWithResult:result];
+        else if ([_DO_MANUAL_CALIBRATION_OVER_BLUETOOTH isEqualToString:call.method])
+            [printer doManualCalibrationOverBluetooth:arguments[_macAddress]];
+        else if ([_PRINT_CONFIGURATION_LABEL_OVER_BLUETOOTH isEqualToString:call.method])
+            [printer printConfigurationLabelOverBluetooth:arguments[_macAddress]];
+        else if ([_CHECK_PRINTER_STATUS_OVER_BLUETOOTH isEqualToString:call.method])
+            [printer checkPrinterStatusOverBluetooth:arguments[_macAddress]];
+        else if ([_GET_PRINTER_SETTINGS_OVER_BLUETOOTH isEqualToString:call.method])
+            [printer getPrinterSettingsOverBluetooth:arguments[_macAddress]];
+        else if ([_SET_PRINTER_SETTINGS_OVER_BLUETOOTH isEqualToString:call.method])
+            [printer setPrinterSettingsOverBluetooth:arguments[_macAddress] settings:[[PrinterSettings alloc] initWithArguments:arguments]];
+        else if ([_PRINT_PDF_FILE_OVER_BLUETOOTH isEqualToString:call.method])
+            [printer printPdfFileOverBluetooth:arguments[_filePath] macAddress:arguments[_macAddress]];
+        else if ([_PRINT_ZPL_FILE_OVER_BLUETOOTH isEqualToString:call.method])
+            [printer printZplFileOverBluetooth:arguments[_filePath] macAddress:arguments[_macAddress]];
+        else if ([_PRINT_ZPL_DATA_OVER_BLUETOOTH isEqualToString:call.method])
+            [printer printZplDataOverBluetooth:arguments[_data] macAddress:arguments[_macAddress]];
+        else if ([_REBOOT_PRINTER_OVER_BLUETOOTH isEqualToString:call.method])
+            [printer rebootPrinterOverBluetooth:arguments[_macAddress]];
         else result(FlutterMethodNotImplemented);
     } @catch (NSException *e) {
         StatusInfo *statusInfo = [[StatusInfo alloc] init:UNKNOWN_STATUS cause:UNKNOWN_CAUSE];
@@ -214,6 +219,27 @@ NSString* _dpi = @"dpi";
         result([FlutterError errorWithCode:[response getErrorCode] message: response.message details:[response toMap]]);
     }
 }
-       
+
+- (void)getBondedDevicesWithResult:(FlutterResult)result {
+    @try {
+        NSMutableArray *deviceList = [[NSMutableArray alloc] init];
+
+        EAAccessoryManager *sam = [EAAccessoryManager sharedAccessoryManager];
+        NSArray *connectedAccessories = [sam connectedAccessories];
+
+        for (EAAccessory *accessory in connectedAccessories) {
+            if ([accessory.protocolStrings indexOfObject:@"com.zebra.rawport"] != NSNotFound) {
+                NSMutableDictionary *deviceMap = [[NSMutableDictionary alloc] init];
+                [deviceMap setObject:(accessory.name != nil ? accessory.name : @"Unknown") forKey:@"name"];
+                [deviceMap setObject:accessory.serialNumber forKey:@"address"];
+                [deviceList addObject:deviceMap];
+            }
+        }
+
+        result(deviceList);
+    } @catch (NSException *e) {
+        result([FlutterError errorWithCode:@"BLUETOOTH_ERROR" message:[NSString stringWithFormat:@"Failed to get bonded devices: %@", e.reason] details:nil]);
+    }
+}
 
 @end

--- a/lib/zsdk.dart
+++ b/lib/zsdk.dart
@@ -52,11 +52,39 @@ class ZSDK {
       "printConfigurationLabelOverTCPIP";
   static const String _REBOOT_PRINTER_OVER_TCP_IP = "rebootPrinterOverTCPIP";
 
+  /// Methods - Bluetooth
+  static const String _PRINT_PDF_FILE_OVER_BLUETOOTH =
+      "printPdfFileOverBluetooth";
+  static const String _PRINT_ZPL_FILE_OVER_BLUETOOTH =
+      "printZplFileOverBluetooth";
+  static const String _PRINT_ZPL_DATA_OVER_BLUETOOTH =
+      "printZplDataOverBluetooth";
+  static const String _CHECK_PRINTER_STATUS_OVER_BLUETOOTH =
+      "checkPrinterStatusOverBluetooth";
+  static const String _GET_PRINTER_SETTINGS_OVER_BLUETOOTH =
+      "getPrinterSettingsOverBluetooth";
+  static const String _SET_PRINTER_SETTINGS_OVER_BLUETOOTH =
+      "setPrinterSettingsOverBluetooth";
+  static const String _DO_MANUAL_CALIBRATION_OVER_BLUETOOTH =
+      "doManualCalibrationOverBluetooth";
+  static const String _PRINT_CONFIGURATION_LABEL_OVER_BLUETOOTH =
+      "printConfigurationLabelOverBluetooth";
+  static const String _REBOOT_PRINTER_OVER_BLUETOOTH =
+      "rebootPrinterOverBluetooth";
+
+  /// Methods - Bluetooth Connection Management
+  static const String _CONNECT_BLUETOOTH = "connectBluetooth";
+  static const String _DISCONNECT_BLUETOOTH = "disconnectBluetooth";
+  static const String _IS_BLUETOOTH_CONNECTED = "isBluetoothConnected";
+  static const String _GET_BONDED_DEVICES = "getBondedDevices";
+  static const String _DISCOVER_BLUETOOTH_PRINTERS = "discoverBluetoothPrinters";
+
   /// Properties
   static const String _filePath = "filePath";
   static const String _data = "data";
   static const String _address = "address";
   static const String _port = "port";
+  static const String _macAddress = "macAddress";
   static const String _cmWidth = "cmWidth";
   static const String _cmHeight = "cmHeight";
   static const String _orientation = "orientation";
@@ -256,4 +284,189 @@ class ZSDK {
       }).timeout(
           timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
           onTimeout: () => _onTimeout(timeout: timeout));
+
+  Future doManualCalibrationOverBluetooth(
+          {required String macAddress, Duration? timeout}) =>
+      _channel.invokeMethod(_DO_MANUAL_CALIBRATION_OVER_BLUETOOTH, {
+        _macAddress: macAddress,
+      }).timeout(
+          timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+          onTimeout: () => _onTimeout(timeout: timeout));
+
+  Future printConfigurationLabelOverBluetooth(
+          {required String macAddress, Duration? timeout}) =>
+      _channel.invokeMethod(_PRINT_CONFIGURATION_LABEL_OVER_BLUETOOTH, {
+        _macAddress: macAddress,
+      }).timeout(
+          timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+          onTimeout: () => _onTimeout(timeout: timeout));
+
+  Future rebootPrinterOverBluetooth(
+          {required String macAddress, Duration? timeout}) =>
+      _channel.invokeMethod(_REBOOT_PRINTER_OVER_BLUETOOTH, {
+        _macAddress: macAddress,
+      }).timeout(
+          timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+          onTimeout: () => _onTimeout(timeout: timeout));
+
+  Future checkPrinterStatusOverBluetooth(
+          {required String macAddress, Duration? timeout}) =>
+      _channel.invokeMethod(_CHECK_PRINTER_STATUS_OVER_BLUETOOTH, {
+        _macAddress: macAddress,
+      }).timeout(
+          timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+          onTimeout: () => _onTimeout(timeout: timeout));
+
+  Future getPrinterSettingsOverBluetooth(
+          {required String macAddress, Duration? timeout}) =>
+      _channel.invokeMethod(_GET_PRINTER_SETTINGS_OVER_BLUETOOTH, {
+        _macAddress: macAddress,
+      }).timeout(
+          timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+          onTimeout: () => _onTimeout(timeout: timeout));
+
+  Future setPrinterSettingsOverBluetooth(
+          {required PrinterSettings settings,
+          required String macAddress,
+          Duration? timeout}) =>
+      _channel
+          .invokeMethod(
+              _SET_PRINTER_SETTINGS_OVER_BLUETOOTH,
+              <String, dynamic>{
+                _macAddress: macAddress,
+              }..addAll(settings.toMap()))
+          .timeout(
+              timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+              onTimeout: () => _onTimeout(timeout: timeout));
+
+  Future resetPrinterSettingsOverBluetooth(
+          {required String macAddress, Duration? timeout}) =>
+      setPrinterSettingsOverBluetooth(
+          settings: PrinterSettings.defaultSettings(),
+          macAddress: macAddress,
+          timeout: timeout);
+
+  Future printPdfFileOverBluetooth(
+          {required String filePath,
+          required String macAddress,
+          PrinterConf? printerConf,
+          Duration? timeout}) =>
+      _printFileOverBluetooth(
+          method: _PRINT_PDF_FILE_OVER_BLUETOOTH,
+          filePath: filePath,
+          macAddress: macAddress,
+          printerConf: printerConf,
+          timeout: timeout);
+
+  Future printZplFileOverBluetooth(
+          {required String filePath,
+          required String macAddress,
+          PrinterConf? printerConf,
+          Duration? timeout}) =>
+      _printFileOverBluetooth(
+          method: _PRINT_ZPL_FILE_OVER_BLUETOOTH,
+          filePath: filePath,
+          macAddress: macAddress,
+          printerConf: printerConf,
+          timeout: timeout);
+
+  Future _printFileOverBluetooth(
+          {required method,
+          required String filePath,
+          required String macAddress,
+          PrinterConf? printerConf,
+          Duration? timeout}) =>
+      _channel.invokeMethod(method, {
+        _filePath: filePath,
+        _macAddress: macAddress,
+        _cmWidth: printerConf?.cmWidth,
+        _cmHeight: printerConf?.cmHeight,
+        _dpi: printerConf?.dpi,
+        _orientation: printerConf?.orientation?.name,
+      }).timeout(
+          timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+          onTimeout: () => _onTimeout(timeout: timeout));
+
+  Future printZplDataOverBluetooth(
+          {required String data,
+          required String macAddress,
+          PrinterConf? printerConf,
+          Duration? timeout}) =>
+      _printDataOverBluetooth(
+          method: _PRINT_ZPL_DATA_OVER_BLUETOOTH,
+          data: data,
+          macAddress: macAddress,
+          printerConf: printerConf,
+          timeout: timeout);
+
+  Future _printDataOverBluetooth(
+          {required method,
+          required dynamic data,
+          required String macAddress,
+          PrinterConf? printerConf,
+          Duration? timeout}) =>
+      _channel.invokeMethod(method, {
+        _data: data,
+        _macAddress: macAddress,
+        _cmWidth: printerConf?.cmWidth,
+        _cmHeight: printerConf?.cmHeight,
+        _dpi: printerConf?.dpi,
+        _orientation: printerConf?.orientation?.name,
+      }).timeout(
+          timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+          onTimeout: () => _onTimeout(timeout: timeout));
+
+  Future<Map<dynamic, dynamic>> connectBluetooth({
+    required String macAddress,
+    Duration? timeout,
+  }) async {
+    final result = await _channel.invokeMethod(_CONNECT_BLUETOOTH, {
+      _macAddress: macAddress,
+    }).timeout(
+        timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT * 2),
+        onTimeout: () => _onTimeout(timeout: timeout));
+    return result as Map<dynamic, dynamic>;
+  }
+
+  Future<bool> disconnectBluetooth({Duration? timeout}) async {
+    final result = await _channel.invokeMethod(_DISCONNECT_BLUETOOTH).timeout(
+        timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+        onTimeout: () => _onTimeout(timeout: timeout));
+    return result == true;
+  }
+
+  Future<bool> isBluetoothConnected({String? macAddress}) async {
+    final result = await _channel.invokeMethod(_IS_BLUETOOTH_CONNECTED, {
+      if (macAddress != null) _macAddress: macAddress,
+    });
+    return result == true;
+  }
+
+  Future<List<Map<String, String>>> getBondedDevices() async {
+    final result = await _channel.invokeMethod(_GET_BONDED_DEVICES);
+    if (result == null) return [];
+    return (result as List).map((device) {
+      final map = device as Map;
+      return {
+        'name': map['name']?.toString() ?? 'Unknown',
+        'address': map['address']?.toString() ?? '',
+      };
+    }).toList();
+  }
+
+  Future<List<Map<String, String>>> discoverBluetoothPrinters({
+    Duration? timeout,
+  }) async {
+    final result = await _channel.invokeMethod(_DISCOVER_BLUETOOTH_PRINTERS).timeout(
+        timeout ??= const Duration(seconds: 30),
+        onTimeout: () => <Map<String, String>>[]);
+    if (result == null) return [];
+    return (result as List).map((device) {
+      final map = device as Map;
+      return {
+        'name': map['name']?.toString() ?? 'Unknown',
+        'address': map['address']?.toString() ?? '',
+      };
+    }).toList();
+  }
 }


### PR DESCRIPTION
It works!

Tested on my Android and on iOS - using my own app (using zsdk from disk as dependency).

Since my app has all it needs already I decided to test using  that instead adding stuff to the example app - that way I didn't need to make anything new, and I know how it should work.

As we discussed the Bluetooth config is not part of the library, and consumers must provide this them selves (permissions etc.).

My app also supports connecting with NFC - but that's not part of the zebra SDK, that is done outside.

<img width="1033" height="1377" alt="image" src="https://github.com/user-attachments/assets/bf146d2b-6dae-4d6c-a157-3dce962ff2ed" />
