### PR TITLE
Expose methods to get and change printer language

### DIFF
--- a/android/src/main/java/com/plugin/flutter/zsdk/ZPrinter.java
+++ b/android/src/main/java/com/plugin/flutter/zsdk/ZPrinter.java
@@ -864,4 +864,144 @@ public class ZPrinter
             }
         }).start();
     }
+
+    public void changePrinterLanguageOverTCPIP(final String address, final Integer port, final String language) {
+        new Thread(() -> {
+            Connection connection;
+            try {
+                int tcpPort = port != null ? port : TcpConnection.DEFAULT_ZPL_TCP_PORT;
+                connection = newConnection(address, tcpPort);
+                connection.open();
+
+                try {
+                    changePrinterLanguage(connection, language);
+                    String actualLanguage = SGD.GET(SGDParams.KEY_PRINTER_LANGUAGES, connection);
+                    PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                            new StatusInfo(Status.READY_TO_PRINT, Cause.UNKNOWN),
+                            "Printer language changed to " + actualLanguage);
+                    Map<String, Object> resultMap = response.toMap();
+                    resultMap.put("language", actualLanguage);
+                    handler.post(() -> result.success(resultMap));
+                } finally {
+                    connection.close();
+                }
+            } catch (ConnectionException e) {
+                onConnectionTimeOut(e);
+            } catch (Exception e) {
+                onException(e, null);
+            }
+        }).start();
+    }
+
+    public void getPrinterLanguageOverTCPIP(final String address, final Integer port) {
+        new Thread(() -> {
+            Connection connection;
+            try {
+                int tcpPort = port != null ? port : TcpConnection.DEFAULT_ZPL_TCP_PORT;
+                connection = newConnection(address, tcpPort);
+                connection.open();
+
+                try {
+                    String printerLanguage = SGD.GET(SGDParams.KEY_PRINTER_LANGUAGES, connection);
+                    PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                            new StatusInfo(Status.READY_TO_PRINT, Cause.UNKNOWN),
+                            "Current printer language: " + printerLanguage);
+                    Map<String, Object> resultMap = response.toMap();
+                    resultMap.put("language", printerLanguage);
+                    handler.post(() -> result.success(resultMap));
+                } finally {
+                    connection.close();
+                }
+            } catch (ConnectionException e) {
+                onConnectionTimeOut(e);
+            } catch (Exception e) {
+                onException(e, null);
+            }
+        }).start();
+    }
+
+    public void changePrinterLanguageOverBluetooth(final String macAddress, final String language) {
+        new Thread(() -> {
+            Connection connection = null;
+            boolean shouldCloseConnection = shouldManageConnection;
+            try {
+                if (activeBluetoothConnection != null && !shouldManageConnection) {
+                    try {
+                        if (activeBluetoothConnection.isConnected()) {
+                            connection = activeBluetoothConnection;
+                            shouldCloseConnection = false;
+                        }
+                    } catch (Exception ignored) {
+                    }
+                }
+
+                if (connection == null) {
+                    connection = newBluetoothConnection(macAddress);
+                    connection.open();
+                    shouldCloseConnection = true;
+                }
+
+                try {
+                    changePrinterLanguage(connection, language);
+                    String actualLanguage = SGD.GET(SGDParams.KEY_PRINTER_LANGUAGES, connection);
+                    PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                            new StatusInfo(Status.READY_TO_PRINT, Cause.UNKNOWN),
+                            "Printer language changed to " + actualLanguage);
+                    Map<String, Object> resultMap = response.toMap();
+                    resultMap.put("language", actualLanguage);
+                    handler.post(() -> result.success(resultMap));
+                } finally {
+                    if (shouldCloseConnection && connection != null) {
+                        connection.close();
+                    }
+                }
+            } catch (ConnectionException e) {
+                onConnectionTimeOut(e);
+            } catch (Exception e) {
+                onException(e, null);
+            }
+        }).start();
+    }
+
+    public void getPrinterLanguageOverBluetooth(final String macAddress) {
+        new Thread(() -> {
+            Connection connection = null;
+            boolean shouldCloseConnection = shouldManageConnection;
+            try {
+                if (activeBluetoothConnection != null && !shouldManageConnection) {
+                    try {
+                        if (activeBluetoothConnection.isConnected()) {
+                            connection = activeBluetoothConnection;
+                            shouldCloseConnection = false;
+                        }
+                    } catch (Exception ignored) {
+                    }
+                }
+
+                if (connection == null) {
+                    connection = newBluetoothConnection(macAddress);
+                    connection.open();
+                    shouldCloseConnection = true;
+                }
+
+                try {
+                    String printerLanguage = SGD.GET(SGDParams.KEY_PRINTER_LANGUAGES, connection);
+                    PrinterResponse response = new PrinterResponse(ErrorCode.SUCCESS,
+                            new StatusInfo(Status.READY_TO_PRINT, Cause.UNKNOWN),
+                            "Current printer language: " + printerLanguage);
+                    Map<String, Object> resultMap = response.toMap();
+                    resultMap.put("language", printerLanguage);
+                    handler.post(() -> result.success(resultMap));
+                } finally {
+                    if (shouldCloseConnection && connection != null) {
+                        connection.close();
+                    }
+                }
+            } catch (ConnectionException e) {
+                onConnectionTimeOut(e);
+            } catch (Exception e) {
+                onException(e, null);
+            }
+        }).start();
+    }
 }

--- a/android/src/main/java/com/plugin/flutter/zsdk/ZsdkPlugin.java
+++ b/android/src/main/java/com/plugin/flutter/zsdk/ZsdkPlugin.java
@@ -104,6 +104,15 @@ public class ZsdkPlugin implements FlutterPlugin, MethodCallHandler {
   static final String _GET_BONDED_DEVICES = "getBondedDevices";
   static final String _DISCOVER_BLUETOOTH_PRINTERS = "discoverBluetoothPrinters";
 
+  /** Methods - Printer Language */
+  static final String _CHANGE_PRINTER_LANGUAGE_OVER_TCP_IP = "changePrinterLanguageOverTCPIP";
+  static final String _GET_PRINTER_LANGUAGE_OVER_TCP_IP = "getPrinterLanguageOverTCPIP";
+  static final String _CHANGE_PRINTER_LANGUAGE_OVER_BLUETOOTH = "changePrinterLanguageOverBluetooth";
+  static final String _GET_PRINTER_LANGUAGE_OVER_BLUETOOTH = "getPrinterLanguageOverBluetooth";
+
+  /** Properties */
+  static final String _language = "language";
+
   /** Properties */
   static final String _filePath = "filePath";
   static final String _data = "data";
@@ -287,6 +296,30 @@ public class ZsdkPlugin implements FlutterPlugin, MethodCallHandler {
           break;
         case _REBOOT_PRINTER_OVER_BLUETOOTH:
           printer.rebootPrinterOverBluetooth(
+              call.argument(_macAddress)
+          );
+          break;
+        case _CHANGE_PRINTER_LANGUAGE_OVER_TCP_IP:
+          printer.changePrinterLanguageOverTCPIP(
+              call.argument(_address),
+              call.argument(_port),
+              call.argument(_language)
+          );
+          break;
+        case _GET_PRINTER_LANGUAGE_OVER_TCP_IP:
+          printer.getPrinterLanguageOverTCPIP(
+              call.argument(_address),
+              call.argument(_port)
+          );
+          break;
+        case _CHANGE_PRINTER_LANGUAGE_OVER_BLUETOOTH:
+          printer.changePrinterLanguageOverBluetooth(
+              call.argument(_macAddress),
+              call.argument(_language)
+          );
+          break;
+        case _GET_PRINTER_LANGUAGE_OVER_BLUETOOTH:
+          printer.getPrinterLanguageOverBluetooth(
               call.argument(_macAddress)
           );
           break;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,10 +20,16 @@ const String btnResetPrinterSettings = 'btnResetPrinterSettings';
 const String btnDoManualCalibration = 'btnDoManualCalibration';
 const String btnPrintConfigurationLabel = 'btnPrintConfigurationLabel';
 const String btnRebootPrinter = 'btnRebootPrinter';
+const String btnGetPrinterLanguage = 'btnGetPrinterLanguage';
+const String btnChangePrinterLanguage = 'btnChangePrinterLanguage';
 
 const String btnGetBondedDevices = 'btnGetBondedDevices';
 const String btnDiscoverPrinters = 'btnDiscoverPrinters';
 const String btnPrintZplDataOverBluetooth = 'btnPrintZplDataOverBluetooth';
+const String btnGetPrinterLanguageOverBluetooth =
+    'btnGetPrinterLanguageOverBluetooth';
+const String btnChangePrinterLanguageOverBluetooth =
+    'btnChangePrinterLanguageOverBluetooth';
 
 class MyApp extends StatefulWidget {
   final Printer.ZSDK zsdk = Printer.ZSDK();
@@ -57,6 +63,7 @@ class _MyAppState extends State<MyApp> {
   final labelLengthMaxController = TextEditingController();
   final labelTopController = TextEditingController();
   final leftPositionController = TextEditingController();
+  final languageController = TextEditingController(text: 'hybrid_xml_zpl');
   Printer.MediaType? selectedMediaType;
   Printer.PrintMethod? selectedPrintMethod;
   Printer.ZPLMode? selectedZPLMode;
@@ -78,6 +85,8 @@ class _MyAppState extends State<MyApp> {
   OperationStatus settingsStatus = OperationStatus.NONE;
   OperationStatus calibrationStatus = OperationStatus.NONE;
   OperationStatus rebootingStatus = OperationStatus.NONE;
+  OperationStatus languageStatus = OperationStatus.NONE;
+  String? languageMessage;
   OperationStatus btStatus = OperationStatus.NONE;
   String? btMessage;
   String? filePath;
@@ -365,6 +374,85 @@ class _MyAppState extends State<MyApp> {
                                     : () => onClick(btnRebootPrinter),
                                 child: Text(
                                   'Reboot Printer'.toUpperCase(),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Card(
+                  elevation: 4,
+                  margin: const EdgeInsets.all(8),
+                  child: Container(
+                    padding: const EdgeInsets.all(8),
+                    child: Column(
+                      children: <Widget>[
+                        const Text(
+                          'Printer language',
+                          style: TextStyle(fontSize: 16),
+                        ),
+                        TextField(
+                          controller: languageController,
+                          decoration: const InputDecoration(
+                            labelText:
+                                'Language (e.g. hybrid_xml_zpl, zpl, cpcl, dpl, line_print)',
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        Visibility(
+                          visible: languageStatus != OperationStatus.NONE,
+                          child: Column(
+                            children: <Widget>[
+                              Text(
+                                '$languageMessage',
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                  color: getOperationStatusColor(
+                                    languageStatus,
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(height: 16),
+                            ],
+                          ),
+                        ),
+                        Row(
+                          children: <Widget>[
+                            Expanded(
+                              child: ElevatedButton(
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: Colors.brown,
+                                  foregroundColor: Colors.white,
+                                ),
+                                onPressed:
+                                    languageStatus == OperationStatus.RECEIVING
+                                    ? null
+                                    : () => onClick(btnGetPrinterLanguage),
+                                child: Text(
+                                  'Get language'.toUpperCase(),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            ),
+                            const VerticalDivider(color: Colors.transparent),
+                            Expanded(
+                              child: ElevatedButton(
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: Colors.deepOrange,
+                                  foregroundColor: Colors.white,
+                                ),
+                                onPressed:
+                                    languageStatus == OperationStatus.SENDING
+                                    ? null
+                                    : () => onClick(btnChangePrinterLanguage),
+                                child: Text(
+                                  'Change language'.toUpperCase(),
                                   textAlign: TextAlign.center,
                                 ),
                               ),
@@ -1075,6 +1163,47 @@ class _MyAppState extends State<MyApp> {
                             ),
                           ],
                         ),
+                        const SizedBox(height: 8),
+                        Row(
+                          children: <Widget>[
+                            Expanded(
+                              child: ElevatedButton(
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: Colors.brown,
+                                  foregroundColor: Colors.white,
+                                ),
+                                onPressed:
+                                    btStatus == OperationStatus.RECEIVING
+                                    ? null
+                                    : () => onClick(
+                                        btnGetPrinterLanguageOverBluetooth,
+                                      ),
+                                child: Text(
+                                  'Get language'.toUpperCase(),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: ElevatedButton(
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: Colors.deepOrange,
+                                  foregroundColor: Colors.white,
+                                ),
+                                onPressed: btStatus == OperationStatus.SENDING
+                                    ? null
+                                    : () => onClick(
+                                        btnChangePrinterLanguageOverBluetooth,
+                                      ),
+                                child: Text(
+                                  'Change language'.toUpperCase(),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
                       ],
                     ),
                   ),
@@ -1464,6 +1593,96 @@ class _MyAppState extends State<MyApp> {
                 },
               );
           break;
+        case btnGetPrinterLanguage:
+          setState(() {
+            languageMessage = 'Getting printer language...';
+            languageStatus = OperationStatus.RECEIVING;
+          });
+          widget.zsdk
+              .getPrinterLanguageOverTCPIP(
+                address: addressIpController.text,
+                port: int.tryParse(addressPortController.text),
+              )
+              .then(
+                (value) {
+                  setState(() {
+                    languageStatus = OperationStatus.SUCCESS;
+                    languageMessage = '$value';
+                  });
+                },
+                onError: (error, stacktrace) {
+                  try {
+                    throw error;
+                  } on PlatformException catch (e) {
+                    Printer.PrinterResponse printerResponse;
+                    try {
+                      printerResponse = Printer.PrinterResponse.fromMap(
+                        e.details,
+                      );
+                      languageMessage =
+                          '${printerResponse.message} ${printerResponse.errorCode} ${printerResponse.statusInfo.status} ${printerResponse.statusInfo.cause}';
+                    } catch (e) {
+                      print(e);
+                      languageMessage = e.toString();
+                    }
+                  } on MissingPluginException catch (e) {
+                    languageMessage = '${e.message}';
+                  } catch (e) {
+                    languageMessage = e.toString();
+                  }
+                  setState(() {
+                    languageStatus = OperationStatus.ERROR;
+                  });
+                },
+              );
+          break;
+        case btnChangePrinterLanguage:
+          if (languageController.text.isEmpty) {
+            throw Exception("Language can't be empty");
+          }
+          setState(() {
+            languageMessage = 'Changing printer language...';
+            languageStatus = OperationStatus.SENDING;
+          });
+          widget.zsdk
+              .changePrinterLanguageOverTCPIP(
+                address: addressIpController.text,
+                port: int.tryParse(addressPortController.text),
+                language: languageController.text,
+              )
+              .then(
+                (value) {
+                  setState(() {
+                    languageStatus = OperationStatus.SUCCESS;
+                    languageMessage = '$value';
+                  });
+                },
+                onError: (error, stacktrace) {
+                  try {
+                    throw error;
+                  } on PlatformException catch (e) {
+                    Printer.PrinterResponse printerResponse;
+                    try {
+                      printerResponse = Printer.PrinterResponse.fromMap(
+                        e.details,
+                      );
+                      languageMessage =
+                          '${printerResponse.message} ${printerResponse.errorCode} ${printerResponse.statusInfo.status} ${printerResponse.statusInfo.cause}';
+                    } catch (e) {
+                      print(e);
+                      languageMessage = e.toString();
+                    }
+                  } on MissingPluginException catch (e) {
+                    languageMessage = '${e.message}';
+                  } catch (e) {
+                    languageMessage = e.toString();
+                  }
+                  setState(() {
+                    languageStatus = OperationStatus.ERROR;
+                  });
+                },
+              );
+          break;
         case btnPrintConfigurationLabel:
           setState(() {
             message = 'Print job started...';
@@ -1758,6 +1977,100 @@ class _MyAppState extends State<MyApp> {
               .printZplDataOverBluetooth(
                 data: zplData!,
                 macAddress: btMacAddressController.text,
+              )
+              .then(
+                (value) {
+                  setState(() {
+                    btStatus = OperationStatus.SUCCESS;
+                    btMessage = '$value';
+                  });
+                },
+                onError: (error, stacktrace) {
+                  try {
+                    throw error;
+                  } on PlatformException catch (e) {
+                    Printer.PrinterResponse printerResponse;
+                    try {
+                      printerResponse = Printer.PrinterResponse.fromMap(
+                        e.details,
+                      );
+                      btMessage =
+                          '${printerResponse.message} ${printerResponse.errorCode} ${printerResponse.statusInfo.status} ${printerResponse.statusInfo.cause}';
+                    } catch (e) {
+                      print(e);
+                      btMessage = e.toString();
+                    }
+                  } on MissingPluginException catch (e) {
+                    btMessage = '${e.message}';
+                  } catch (e) {
+                    btMessage = e.toString();
+                  }
+                  setState(() {
+                    btStatus = OperationStatus.ERROR;
+                  });
+                },
+              );
+          break;
+        case btnGetPrinterLanguageOverBluetooth:
+          if (btMacAddressController.text.isEmpty) {
+            throw Exception("MAC address can't be empty");
+          }
+          setState(() {
+            btMessage = 'Getting printer language...';
+            btStatus = OperationStatus.RECEIVING;
+          });
+          widget.zsdk
+              .getPrinterLanguageOverBluetooth(
+                macAddress: btMacAddressController.text,
+              )
+              .then(
+                (value) {
+                  setState(() {
+                    btStatus = OperationStatus.SUCCESS;
+                    btMessage = '$value';
+                  });
+                },
+                onError: (error, stacktrace) {
+                  try {
+                    throw error;
+                  } on PlatformException catch (e) {
+                    Printer.PrinterResponse printerResponse;
+                    try {
+                      printerResponse = Printer.PrinterResponse.fromMap(
+                        e.details,
+                      );
+                      btMessage =
+                          '${printerResponse.message} ${printerResponse.errorCode} ${printerResponse.statusInfo.status} ${printerResponse.statusInfo.cause}';
+                    } catch (e) {
+                      print(e);
+                      btMessage = e.toString();
+                    }
+                  } on MissingPluginException catch (e) {
+                    btMessage = '${e.message}';
+                  } catch (e) {
+                    btMessage = e.toString();
+                  }
+                  setState(() {
+                    btStatus = OperationStatus.ERROR;
+                  });
+                },
+              );
+          break;
+        case btnChangePrinterLanguageOverBluetooth:
+          if (btMacAddressController.text.isEmpty) {
+            throw Exception("MAC address can't be empty");
+          }
+          if (languageController.text.isEmpty) {
+            throw Exception("Language can't be empty");
+          }
+          setState(() {
+            btMessage = 'Changing printer language...';
+            btStatus = OperationStatus.SENDING;
+          });
+          widget.zsdk
+              .changePrinterLanguageOverBluetooth(
+                macAddress: btMacAddressController.text,
+                language: languageController.text,
               )
               .then(
                 (value) {

--- a/lib/zsdk.dart
+++ b/lib/zsdk.dart
@@ -80,6 +80,16 @@ class ZSDK {
   static const String _DISCOVER_BLUETOOTH_PRINTERS =
       'discoverBluetoothPrinters';
 
+  /// Methods - Printer Language
+  static const String _CHANGE_PRINTER_LANGUAGE_OVER_TCP_IP =
+      'changePrinterLanguageOverTCPIP';
+  static const String _GET_PRINTER_LANGUAGE_OVER_TCP_IP =
+      'getPrinterLanguageOverTCPIP';
+  static const String _CHANGE_PRINTER_LANGUAGE_OVER_BLUETOOTH =
+      'changePrinterLanguageOverBluetooth';
+  static const String _GET_PRINTER_LANGUAGE_OVER_BLUETOOTH =
+      'getPrinterLanguageOverBluetooth';
+
   /// Properties
   static const String _filePath = 'filePath';
   static const String _data = 'data';
@@ -90,6 +100,7 @@ class ZSDK {
   static const String _cmHeight = 'cmHeight';
   static const String _orientation = 'orientation';
   static const String _dpi = 'dpi';
+  static const String _language = 'language';
 
   late MethodChannel _channel;
 
@@ -470,5 +481,69 @@ class ZSDK {
         'address': map['address']?.toString() ?? '',
       };
     }).toList();
+  }
+
+  /// Changes the printer language over TCP/IP.
+  /// [language] can be null to use the default ZPL language (hybrid_xml_zpl).
+  /// Common values: "hybrid_xml_zpl", "zpl", "cpcl", "dpl".
+  Future<Map<dynamic, dynamic>> changePrinterLanguageOverTCPIP({
+    required String address,
+    int? port,
+    String? language,
+    Duration? timeout,
+  }) async {
+    final result = await _channel.invokeMethod(_CHANGE_PRINTER_LANGUAGE_OVER_TCP_IP, {
+      _address: address,
+      _port: port,
+      _language: language,
+    }).timeout(
+        timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+        onTimeout: () => _onTimeout(timeout: timeout));
+    return result as Map<dynamic, dynamic>;
+  }
+
+  /// Gets the current printer language over TCP/IP.
+  Future<Map<dynamic, dynamic>> getPrinterLanguageOverTCPIP({
+    required String address,
+    int? port,
+    Duration? timeout,
+  }) async {
+    final result = await _channel.invokeMethod(_GET_PRINTER_LANGUAGE_OVER_TCP_IP, {
+      _address: address,
+      _port: port,
+    }).timeout(
+        timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+        onTimeout: () => _onTimeout(timeout: timeout));
+    return result as Map<dynamic, dynamic>;
+  }
+
+  /// Changes the printer language over Bluetooth.
+  /// [language] can be null to use the default ZPL language (hybrid_xml_zpl).
+  /// Common values: "hybrid_xml_zpl", "zpl", "cpcl", "dpl".
+  Future<Map<dynamic, dynamic>> changePrinterLanguageOverBluetooth({
+    required String macAddress,
+    String? language,
+    Duration? timeout,
+  }) async {
+    final result = await _channel.invokeMethod(_CHANGE_PRINTER_LANGUAGE_OVER_BLUETOOTH, {
+      _macAddress: macAddress,
+      _language: language,
+    }).timeout(
+        timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+        onTimeout: () => _onTimeout(timeout: timeout));
+    return result as Map<dynamic, dynamic>;
+  }
+
+  /// Gets the current printer language over Bluetooth.
+  Future<Map<dynamic, dynamic>> getPrinterLanguageOverBluetooth({
+    required String macAddress,
+    Duration? timeout,
+  }) async {
+    final result = await _channel.invokeMethod(_GET_PRINTER_LANGUAGE_OVER_BLUETOOTH, {
+      _macAddress: macAddress,
+    }).timeout(
+        timeout ??= const Duration(seconds: DEFAULT_CONNECTION_TIMEOUT),
+        onTimeout: () => _onTimeout(timeout: timeout));
+    return result as Map<dynamic, dynamic>;
   }
 }


### PR DESCRIPTION

## Title
**Add printer language management methods for TCP/IP and Bluetooth**

## Description

This PR adds functionality to get and change the printer language directly through the ZSDK plugin, making it available to Dart/Flutter callers. Currently it only sets the language to zpl if you send a zpl file. Sending a simple zpl data does not change the language to zpl. Another solution would be to change the zpl function to also set the language, however, I feel like this PR is the more complete solution.

## Changes

### Android (ZPrinter.java)
- Added `changePrinterLanguageOverTCPIP` - Changes printer language via TCP/IP
- Added `getPrinterLanguageOverTCPIP` - Gets current printer language via TCP/IP
- Added `changePrinterLanguageOverBluetooth` - Changes printer language via Bluetooth
- Added `getPrinterLanguageOverBluetooth` - Gets current printer language via Bluetooth

### Plugin (ZsdkPlugin.java)
- Added method constants for language operations:
  - `_CHANGE_PRINTER_LANGUAGE_OVER_TCP_IP`
  - `_GET_PRINTER_LANGUAGE_OVER_TCP_IP`
  - `_CHANGE_PRINTER_LANGUAGE_OVER_BLUETOOTH`
  - `_GET_PRINTER_LANGUAGE_OVER_BLUETOOTH`
- Added `_language` property constant
- Added case handlers in `onMethodCall` switch for all new methods

### Dart (zsdk.dart)
- Added public API methods:
  - `changePrinterLanguageOverTCPIP` with parameters: address, port, language, timeout
  - `getPrinterLanguageOverTCPIP` with parameters: address, port, timeout
  - `changePrinterLanguageOverBluetooth` with parameters: macAddress, language, timeout
  - `getPrinterLanguageOverBluetooth` with parameters: macAddress, timeout
- Added method constants and `_language` property

## Usage

To get the current printer language:
- Call `getPrinterLanguageOverTCPIP` or `getPrinterLanguageOverBluetooth`
- The response map will contain a `language` field with the current language value

To change the printer language:
- Call `changePrinterLanguageOverTCPIP` or `changePrinterLanguageOverBluetooth`
- Pass the desired language as a string parameter
- The response map will contain the actual language that was set

## Notes
- All methods follow the existing timeout and error handling patterns
- Bluetooth methods respect the existing connection management (reuses active connection if available)
- Tested on ZQ320 Plus